### PR TITLE
Make pre-commit hook behave more precisely

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -3,10 +3,11 @@
 echo "**Performing pre-commit actions**"
 
 echo "- Formatting code with spotless"
+# This will format ALL FILES, even unstaged, but that's fine - everything should be formatted when eventually pushed.
 ./gradlew spotlessApply
 
 echo "- Adding any changes from reformat"
-# Add changes for any files already staged
+# Add formatting changes to the commit for any files already staged (added)
 git update-index --again
 
 status=$?

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -2,12 +2,12 @@
 
 echo "**Performing pre-commit actions**"
 
-echo "**Formatting code with spotless**"
+echo "- Formatting code with spotless"
 ./gradlew spotlessApply
 
-echo "**Adding changes from reformat**"
-# Add changes for any files already added to the repo - will not support partial repo commits currently
-git add -u
+echo "- Adding any changes from reformat"
+# Add changes for any files already staged
+git update-index --again
 
 status=$?
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -93,7 +93,6 @@ public class RobotContainer {
                 .onTrue(new ShootAndReturnHome(shooter, arm, () -> robotContext.getShooterSpeed()[0], () -> robotContext
                         .getShooterSpeed()[1]));
 
-        // hey test
         driverController.a().onTrue(new TurnToAngle(drive, AllianceUtil.isRedAlliance() ? 0 : 180));
         driverController
                 .b()

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -93,6 +93,7 @@ public class RobotContainer {
                 .onTrue(new ShootAndReturnHome(shooter, arm, () -> robotContext.getShooterSpeed()[0], () -> robotContext
                         .getShooterSpeed()[1]));
 
+        // hey test
         driverController.a().onTrue(new TurnToAngle(drive, AllianceUtil.isRedAlliance() ? 0 : 180));
         driverController
                 .b()


### PR DESCRIPTION
pre-commit hook now only restages changes for files that have already been staged (via `git add` or similar)