### PR TITLE
Prepare drive subsystem for "brownboxing"

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -59,7 +59,19 @@ public class RobotContainer {
         DataLogManager.log("Data log started.");
 
         poseScheduler = new PoseScheduler();
-        drive = new DriveSubsystem(poseScheduler);
+        drive = new DriveSubsystem(
+                Constants.Drive.MAXIMUM_VELOCITY,
+                Constants.Drive.MAXIMUM_ANGULAR_VELOCITY,
+                Constants.Drive.STEER_GEAR_RATIO,
+                Constants.Drive.PULSE_PER_ROTATION,
+                Constants.Drive.DRIVE_GEAR_RATIO,
+                Constants.Drive.PULSE_PER_ROTATION,
+                Constants.Drive.WHEEL_DIAMETER_METERS,
+                Constants.Drive.ROTATION_P,
+                Constants.Drive.ROTATION_I,
+                Constants.Drive.ROTATION_D,
+                Constants.Drive.ROTATION_TARGET_RANGE,
+                Constants.Drive.MAXIMUM_VISION_POSE_OVERRIDE_DISTANCE);
 
         // visionSubsystem = VisionSubsystem.create();
         ledSubsystem = LEDSubsystem.create();


### PR DESCRIPTION
The goal is to get the drive subsystem to a state where in can be pulled out of the 2024 codebase and dropped into the 2025 codebase.

The main thing keeping the 2024 drive subsystem from being encapsulated was dependency on the static `Constants`. However the way to encapsulate it was to pass in 12+ values FROM the constants file. I don't know if I am a fan of either

@quangdaon 
@CuratorAmber 
@Bholoubek 
@JasonE09 

and any other students

I would like your thoughts on this.

NOTES:
* All dashboard stuff will be deleted from the class
* having a dependency on YAGSL is fine and expected.
* Still need to document the rest of the methods.
* We should probably be using YAGSL `SwerveController` class to turn joystick values into `ChassisSpeeds` but I don't want to "change" how this works until we can experiment with it.